### PR TITLE
Add __version__ information

### DIFF
--- a/src/nifty_ls/__init__.py
+++ b/src/nifty_ls/__init__.py
@@ -5,6 +5,8 @@ from .core import NiftyResult
 
 __all__ = ['lombscargle', 'NiftyResult']
 
+from .version import __version__ as __version__
+
 # Make "fastnifty" available as a method for astropy's Lomb Scargle
 try:
     import astropy.timeseries.periodograms.lombscargle.implementations.main as astropy_ls


### PR DESCRIPTION
Currently `nifty_ls.__version__` returns an error.
This PR should make it possible to run `nifty_ls.__version__` to get a version number that's automatically generated. 