### PR TITLE
add __version__ to __init__.py file

### DIFF
--- a/src/nifty_ls/__init__.py
+++ b/src/nifty_ls/__init__.py
@@ -3,9 +3,10 @@ import logging
 from .core import lombscargle
 from .core import NiftyResult
 
-__all__ = ['lombscargle', 'NiftyResult']
-
 from .version import __version__
+
+__all__ = ['lombscargle', 'NiftyResult', '__version__']
+
 
 # Make "fastnifty" available as a method for astropy's Lomb Scargle
 try:

--- a/src/nifty_ls/__init__.py
+++ b/src/nifty_ls/__init__.py
@@ -5,7 +5,7 @@ from .core import NiftyResult
 
 __all__ = ['lombscargle', 'NiftyResult']
 
-from .version import __version__ as __version__
+from .version import __version__
 
 # Make "fastnifty" available as a method for astropy's Lomb Scargle
 try:

--- a/src/nifty_ls/__init__.py
+++ b/src/nifty_ls/__init__.py
@@ -5,6 +5,8 @@ from .core import NiftyResult
 
 __all__ = ['lombscargle', 'NiftyResult']
 
+from .version import __version__ as __version__
+
 # Make "fastnifty" available as a method for astropy's Lomb Scargle
 try:
     import astropy.timeseries.periodograms.lombscargle.implementations.main as astropy_ls


### PR DESCRIPTION
Sorry, reopening with a new branch.

Currently `nifty_ls.__version__` returns an error.
This PR should make it possible to run `nifty_ls.__version__` to get a version number that's automatically generated.