### PR TITLE
set default dy=None

### DIFF
--- a/src/nifty_ls/core.py
+++ b/src/nifty_ls/core.py
@@ -25,7 +25,7 @@ NORMALIZATION_TYPE = Literal['standard', 'model', 'log', 'psd']
 def lombscargle(
     t: npt.NDArray[np.floating],
     y: npt.NDArray[np.floating],
-    dy: Optional[npt.NDArray[np.floating]],
+    dy: Optional[npt.NDArray[np.floating]] = None,
     fmin: Optional[float] = None,
     fmax: Optional[float] = None,
     Nf: Optional[int] = None,


### PR DESCRIPTION
Setting `dy=None` for `core.lomb_scargle` since otherwise it requires the user to manually set `dy=None` when calling the function.