### PR TITLE
ci: switch Docker image to `nvidia/cuda:12.6.0-devel-rockylinux9`

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,7 +1,7 @@
-FROM nvidia/cuda:12.3.2-runtime-ubuntu22.04
+FROM nvidia/cuda:12.6.0-devel-rockylinux9
 
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+RUN dnf -y update && \
+    dnf -y install \
     python3 \
     python3-pip \
     git

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,7 +1,7 @@
 FROM nvidia/cuda:12.6.0-devel-rockylinux9
 
-RUN dnf -y update && \
-    dnf -y install \
+RUN dnf -y install \
     python3 \
+    python3-devel \
     python3-pip \
     git


### PR DESCRIPTION
cupy currently requires development headers that aren't in the "runtime" CUDA Docker images (https://github.com/cupy/cupy/issues/8466). It seems like eventually the plan is to support CUDA from pip (https://github.com/cupy/cupy/issues/8013), and indeed the headers are already available from the `nvidia-cuda-runtime-cu12` on PyPI, but let's not mix and match CUDA sources unless we need to.

(Also, let's use Rocky instead of Ubuntu, since most users will probably be on a GPU cluster running a RHEL variant.)