### PR TITLE
lombscargle: check that all inputs have the same dtype

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Upcoming
+
+### Enhancements
+- lombscargle: check that all inputs have the same dtype (#59)
+
 ## v1.0.1 (2024-09-12)
 Minor optimizations and fixes that make use of finufft v2.3. This version was used in the submitted research note.
 

--- a/src/nifty_ls/cufinufft.py
+++ b/src/nifty_ls/cufinufft.py
@@ -7,9 +7,11 @@ from __future__ import annotations
 
 from timeit import default_timer as timer
 
+from .utils import same_dtype_or_raise
+
 try:
-    import cupy as cp
     import cufinufft
+    import cupy as cp
 except ImportError as e:
     raise ImportError(
         'cufinufft and cupy are required for this module. Did you install with "pip install nifty-ls[cuda]"?'
@@ -44,10 +46,9 @@ def lombscargle(
     cufinufft is not as finicky to tune as finufft. The default parameters are probably
     fine for most cases, but you may want to experiment with the `eps` and `gpu_method`.
 
-    The cufinufft documentation has a stub pointing to the location in the source code
-    where the tuning parameters can be found:
+    The cufinufft documentation has more information on performance tuning:
 
-    https://finufft.readthedocs.io/en/latest/c_gpu.html#non-standard-options
+    https://finufft.readthedocs.io/en/latest/c_gpu.html#algorithm-performance-options
 
     Parameters
     ----------
@@ -84,6 +85,8 @@ def lombscargle(
     default_cufinufft_kwargs = dict(eps='default', gpu_method=1)
 
     cufinufft_kwargs = {**default_cufinufft_kwargs, **(cufinufft_kwargs or {})}
+
+    same_dtype_or_raise(t=t, y=y, dy=dy)
 
     dtype = t.dtype
 

--- a/src/nifty_ls/finufft.py
+++ b/src/nifty_ls/finufft.py
@@ -8,6 +8,7 @@ import finufft
 import numpy as np
 
 from . import cpu_helpers
+from .utils import same_dtype_or_raise
 
 FFTW_MEASURE = 0
 FFTW_ESTIMATE = 64
@@ -88,6 +89,8 @@ def lombscargle(
     )
 
     finufft_kwargs = {**default_finufft_kwargs, **(finufft_kwargs or {})}
+
+    same_dtype_or_raise(t=t, y=y, dy=dy)
 
     dtype = t.dtype
 

--- a/src/nifty_ls/utils.py
+++ b/src/nifty_ls/utils.py
@@ -51,3 +51,18 @@ def validate_frequency_grid(
     df = (fmax - fmin) / (Nf - 1)  # fmax inclusive
 
     return fmin, df, Nf
+
+
+def same_dtype_or_raise(**arrays):
+    """
+    Check if all arrays have the same dtype, raise ValueError if not.
+    """
+    dtypes = {n: a.dtype for (n, a) in arrays.items() if a is not None}
+    names = list(dtypes.keys())
+
+    for n in names[1:]:
+        if dtypes[n] != dtypes[names[0]]:
+            raise ValueError(
+                f'Arrays {names[0]} and {n} have different dtypes: '
+                f'{dtypes[names[0]]} and {dtypes[n]}'
+            )

--- a/tests/test_ls.py
+++ b/tests/test_ls.py
@@ -266,3 +266,23 @@ def test_backends(data, Nf=1000):
             if backend1 == backend2:
                 continue
             np.testing.assert_allclose(power1, power2, rtol=rtol(dtype, Nf))
+
+
+# GH #58
+def test_mixed_dtypes(data):
+    """Test that calling lombscargle with mixed dtypes raises an exception."""
+    data_mixed = data.copy()
+    data_mixed['t'] = data_mixed['t'].astype(np.float32)
+    data_mixed['y'] = data_mixed['y'].astype(np.float64)
+    data_mixed['dy'] = data_mixed['dy'].astype(np.float64)
+
+    with pytest.raises(ValueError, match='dtype'):
+        nifty_ls.lombscargle(**data_mixed)
+
+    data_mixed = data.copy()
+    data_mixed['t'] = data_mixed['t'].astype(np.float32)
+    data_mixed['y'] = data_mixed['y'].astype(np.float32)
+    data_mixed['dy'] = data_mixed['dy'].astype(np.float64)
+
+    with pytest.raises(ValueError, match='dtype'):
+        nifty_ls.lombscargle(**data_mixed)


### PR DESCRIPTION
Avoids confusing nanobind errors.

We could up-cast automatically, but it seems better to let the user express their intentions since dtype is rather important for Lomb-Scargle.

Closes #58 .