### PR TITLE
free-threaded python and python 3.14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,8 @@ jobs:
             python-version: "3.14"
           - os: macos-14
             python-version: "3.13"
+    env:
+      UV_PYTHON: ${{ matrix.python-version }}
 
     steps:
     - uses: actions/checkout@v4
@@ -38,6 +40,7 @@ jobs:
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
+      id: setup-python
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
@@ -55,7 +58,7 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@v6
       with:
-        version: "0.8.3"
+        version: "0.8.4"
 
     - name: Install from source
       run: |
@@ -66,3 +69,11 @@ jobs:
     - name: Run tests
       run: |
         uv run pytest -vs
+
+    - name: Run free-threaded tests
+      if: endsWith(matrix.python-version, 't')
+      env:
+        NIFTY_LS_FORCE_FREETHREADED_TEST: 1
+      run: |
+        # Needs special treatment to only load nogil-compatible packages
+        uv run --no-dev --exact --group test-freethreaded pytest -xs tests/test_freethreaded.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,10 @@ jobs:
             python-version: "3.13"
           - os: ubuntu-24.04
             python-version: "3.14"
+          - os: ubuntu-24.04
+            python-version: "3.13t"
+          - os: ubuntu-24.04
+            python-version: "3.14t"
           - os: macos-14
             python-version: "3.13"
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,8 @@ jobs:
             python-version: "3.12"
           - os: ubuntu-24.04
             python-version: "3.13"
+          - os: ubuntu-24.04
+            python-version: "3.14"
           - os: macos-14
             python-version: "3.13"
 
@@ -38,6 +40,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
 
     - name: Install LLVM
       if: runner.os == 'macOS'

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -47,7 +47,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
         if: runner.os == 'macOS'  # macos doesn't run in a container and uses external uv
         with:
-          version: "0.8.3"
+          version: "0.8.4"
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.1.2
@@ -74,7 +74,7 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@v6
       with:
-        version: "0.8.3"
+        version: "0.8.4"
 
     - name: Build SDist
       run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS'  # macos doesn't run in a container and uses external uv
         with:
           version: "0.8.3"
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,12 +1,17 @@
 # Changelog
 
-## v1.1.0 (2025-07-29)
+## v1.1.0 (2025-08-01)
 
 This release adds `nterms > 1` support, implemented in the `finufft_chi2` and `cufinufft_chi2` backends.  Thanks to @YuWei-CH for the feature!
+
+Free-threaded Python (3.13t and 3.14t) is also now supported. More generally, we are now building wheels for Python 3.14 and testing against it.
+
+The finufft version requirement is >= 2.3.
 
 ### Enhancements
 - lombscargle: check that all inputs have the same dtype (#59)
 - lombscargle: add support for `nterms > 1` (#60)
+- build: free-threaded python and python 3.14 (#65)
 
 ## v1.0.1 (2024-09-12)
 Minor optimizations and fixes that make use of finufft v2.3. This version was used in the submitted research note.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ set(NIFTY_LS_MODULES cpu_helpers chi2_helpers)
 add_compile_options(-Wno-deprecated-literal-operator)
 
 foreach(MODULE_NAME ${NIFTY_LS_MODULES})
-    nanobind_add_module(${MODULE_NAME} src/nifty_ls/${MODULE_NAME}.cpp NOMINSIZE STABLE_ABI)
+    nanobind_add_module(${MODULE_NAME} src/nifty_ls/${MODULE_NAME}.cpp NOMINSIZE STABLE_ABI FREE_THREADED)
 
     target_compile_options(${MODULE_NAME} PRIVATE
         -Wall -Wextra -std=c++17

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ docstring-code-format = true
 [tool.cibuildwheel]
 archs = "auto64"
 build-frontend = "build[uv]"
+enable = "cpython-freethreading"
 test-command = "pytest -s --benchmark-skip {project}/tests"
 test-groups = "test"
 skip = "pp* *-musllinux_*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,9 @@ dev = [
 ]
 test = [
     "astropy>=6",
+    {include-group = "test-freethreaded"},
+]
+test-freethreaded = [
     "pytest>=8.4.1",
     "pytest-benchmark>=5.1.0",
 ]

--- a/tests/test_freethreaded.py
+++ b/tests/test_freethreaded.py
@@ -1,0 +1,75 @@
+import concurrent.futures
+import os
+import sys
+
+import numpy as np
+import pytest
+
+import nifty_ls
+
+NIFTY_LS_FORCE_FREETHREADED_TEST = (
+    os.environ.get('NIFTY_LS_FORCE_FREETHREADED_TEST', '0') == '1'
+)
+
+
+def nogil_or_exit():
+    try:
+        gil_enabled = sys._is_gil_enabled()
+    except AttributeError:
+        gil_enabled = True
+
+    if gil_enabled:
+        if NIFTY_LS_FORCE_FREETHREADED_TEST:
+            pytest.fail(
+                'NIFTY_LS_FORCE_FREETHREADED_TEST is set, but Python is not running in free-threaded mode.'
+            )
+        else:
+            pytest.skip('Python is not running in free-threaded mode')
+
+
+# NB we don't use pytest.mark.skipif here because we want to check the GIL status at runtime
+
+
+def test_threaded_pool_finufft(N_periodograms=200, N_points=10000):
+    """
+    Test concurrent computation of periodograms using ThreadPoolExecutor with finufft backend.
+    """
+
+    nogil_or_exit()
+
+    rng = np.random.default_rng(42)
+
+    t = np.sort(rng.uniform(0, 100, size=N_points))
+    frequencies = rng.uniform(0.1, 2.0, size=N_periodograms)
+
+    # Generate different y values for each periodogram
+    y_values = np.sin(2 * np.pi * frequencies[:, None] * t) + 0.1 * rng.normal(
+        size=(N_periodograms, N_points)
+    )
+
+    # Parameters for lombscargle
+    common_kwargs = {
+        'backend': 'finufft',
+        'nthreads': 1,  # not required, but recommended
+    }
+
+    def compute_periodogram(y):
+        return nifty_ls.lombscargle(t, y, **common_kwargs)
+
+    # Sequential computation
+    sequential_results = nifty_ls.lombscargle(t, y_values, **common_kwargs).power
+
+    # Parallel computation using ThreadPoolExecutor
+    parallel_results = []
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        futures = [executor.submit(compute_periodogram, y) for y in y_values]
+
+    parallel_results = [future.result() for future in futures]
+
+    # Make sure we have all results
+    assert len(sequential_results) == N_periodograms
+    assert len(parallel_results) == N_periodograms
+
+    # Verify results are the same
+    for seq_res, par_res in zip(sequential_results, parallel_results):
+        np.testing.assert_allclose(seq_res, par_res.power, rtol=1e-4)


### PR DESCRIPTION
This started out as just adding Python 3.14 tests and wheels, but free-threading is not experimental in 3.14, so let's go ahead and add builds and tests for 3.13t and 3.14t.