### PR TITLE
build: bump vendored finufft to 2.5.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ finufft is now a vendored dependency. cufinufft is still external.
 ### Enhancements
 - "heterobatch" mode that supports threading over multiple time series of different lengths is now supported [#66]
 - The vendored finufft for heterobatch has been updated to 2.5.0 [#98]
+- The vendored finufft for heterobatch has been updated to 2.5.1 [#106]
 
 ### Fixes
 - The interpreter no longer crashes in the `finufft_chi2` backend when a singular matrix is encountered. Instead, a `numpy.linalg.LinAlgError` exception is raised. [#86]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ if(NIFTY_LS_HETEROBATCH)
     CPMAddPackage(
         NAME finufft
         GITHUB_REPOSITORY flatironinstitute/finufft
-        GIT_TAG v2.5.0
+        GIT_TAG v2.5.1
         OPTIONS
             "FINUFFT_USE_OPENMP ON"
             "FINUFFT_USE_CPU ON"


### PR DESCRIPTION
should fix the heterobatch crashes due to the race condition in parallel planning