### PR TITLE
Support Win64 build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ minimum-version = "0.8"
 build-dir = "build/{wheel_tag}"
 # editable.rebuild = true  # use with --no-build-isolation
 wheel.py-api = "cp312"
+# Force CMake to use Ninja or MinGW Makefiles rather than Visual Studio
+cmake.args = ["-G Ninja"]
 
 # For debugging:
 # cmake.build-type = "Debug"

--- a/src/nifty_ls/cpu_helpers.cpp
+++ b/src/nifty_ls/cpu_helpers.cpp
@@ -4,6 +4,11 @@
  * of array-wise as occurs in Numpy.
  */
 
+//for compatibility with Windows + MinGW build.
+#ifndef _USE_MATH_DEFINES
+#define _USE_MATH_DEFINES
+#endif
+
 #include <algorithm>
 #include <complex>
 #include <vector>

--- a/src/nifty_ls/cpu_helpers.cpp
+++ b/src/nifty_ls/cpu_helpers.cpp
@@ -4,7 +4,7 @@
  * of array-wise as occurs in Numpy.
  */
 
-//for compatibility with Windows + MinGW build.
+// for compatibility with Windows + MinGW build.
 #ifndef _USE_MATH_DEFINES
 #define _USE_MATH_DEFINES
 #endif


### PR DESCRIPTION
Tweaks to support building on Windows, such that
- `pip install` on Windows should work
- see https://github.com/flatironinstitute/nifty-ls/issues/114#issuecomment-4676554945 for details and caveats (e.g., requiring MinGW)
